### PR TITLE
feat: Epoch-Based Pagination to Ended Proposals

### DIFF
--- a/src/pages/home/components/EpochPagination.tsx
+++ b/src/pages/home/components/EpochPagination.tsx
@@ -84,7 +84,7 @@ export default function EpochPagination({
 
         <div className="flex items-center gap-8">
           <span className="text-sm text-gray-50">Epoch:</span>
-          <div className="w-24">
+          <div className="w-20">
             <TextInput
               type="number"
               value={inputValue}
@@ -93,6 +93,7 @@ export default function EpochPagination({
               size="sm"
               error={inputError}
               disabled={isLoading}
+              className="text-center"
             />
           </div>
           <Button

--- a/src/pages/home/components/EpochPagination.tsx
+++ b/src/pages/home/components/EpochPagination.tsx
@@ -43,8 +43,8 @@ export default function EpochPagination({
       return
     }
 
-    if (epoch > latestEpoch) {
-      setInputError(`Epoch cannot be greater than ${latestEpoch}`)
+    if (epoch > latestEpoch - 1) {
+      setInputError(`Epoch cannot be greater than ${latestEpoch - 1}`)
       return
     }
 
@@ -87,13 +87,13 @@ export default function EpochPagination({
         </Button>
 
         <div className="flex items-center gap-8">
-          <div className="w-32">
+          <div className="min-w-[70px] max-w-[80px]">
             <TextInput
               type="number"
               value={inputValue}
               onChange={handleInputChange}
               onKeyPress={handleKeyPress}
-              size="sm"
+              size="xs"
               error={inputError}
               disabled={isLoading}
               className="text-center"

--- a/src/pages/home/components/EpochPagination.tsx
+++ b/src/pages/home/components/EpochPagination.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@app/components/ui/buttons'
 import { TextInput } from '@app/components/ui/inputs'
@@ -18,6 +18,10 @@ export default function EpochPagination({
   isLoading = false
 }: EpochPaginationProps) {
   const [inputValue, setInputValue] = useState(currentEpoch.toString())
+
+  useEffect(() => {
+    setInputValue(currentEpoch.toString())
+  }, [currentEpoch])
   const [inputError, setInputError] = useState<string>()
 
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -83,8 +87,7 @@ export default function EpochPagination({
         </Button>
 
         <div className="flex items-center gap-8">
-          <span className="text-sm text-gray-50">Epoch:</span>
-          <div className="w-20">
+          <div className="w-32">
             <TextInput
               type="number"
               value={inputValue}
@@ -94,6 +97,7 @@ export default function EpochPagination({
               error={inputError}
               disabled={isLoading}
               className="text-center"
+              placeholder="Epoch"
             />
           </div>
           <Button

--- a/src/pages/home/components/EpochPagination.tsx
+++ b/src/pages/home/components/EpochPagination.tsx
@@ -1,0 +1,125 @@
+import type React from 'react'
+import { useCallback, useState } from 'react'
+
+import { Button } from '@app/components/ui/buttons'
+import { TextInput } from '@app/components/ui/inputs'
+
+interface EpochPaginationProps {
+  currentEpoch: number
+  latestEpoch: number
+  onEpochChange: (epoch: number) => void
+  isLoading?: boolean
+}
+
+export default function EpochPagination({
+  currentEpoch,
+  latestEpoch,
+  onEpochChange,
+  isLoading = false
+}: EpochPaginationProps) {
+  const [inputValue, setInputValue] = useState(currentEpoch.toString())
+  const [inputError, setInputError] = useState<string>()
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target
+    setInputValue(value)
+    setInputError(undefined)
+  }, [])
+
+  const handleInputSubmit = useCallback(() => {
+    const epoch = parseInt(inputValue, 10)
+
+    if (Number.isNaN(epoch)) {
+      setInputError('Please enter a valid epoch number')
+      return
+    }
+
+    if (epoch < 0) {
+      setInputError('Epoch cannot be negative')
+      return
+    }
+
+    if (epoch > latestEpoch) {
+      setInputError(`Epoch cannot be greater than ${latestEpoch}`)
+      return
+    }
+
+    setInputError(undefined)
+    onEpochChange(epoch)
+  }, [inputValue, latestEpoch, onEpochChange])
+
+  const handleKeyPress = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        handleInputSubmit()
+      }
+    },
+    [handleInputSubmit]
+  )
+
+  const handlePrevious = useCallback(() => {
+    if (currentEpoch > 0) {
+      onEpochChange(currentEpoch - 1)
+    }
+  }, [currentEpoch, onEpochChange])
+
+  const handleNext = useCallback(() => {
+    if (currentEpoch < latestEpoch) {
+      onEpochChange(currentEpoch + 1)
+    }
+  }, [currentEpoch, latestEpoch, onEpochChange])
+
+  return (
+    <div className="flex flex-col gap-16 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-12">
+        <Button
+          variant="outlined"
+          size="sm"
+          onClick={handlePrevious}
+          disabled={currentEpoch <= 0 || isLoading}
+          className="w-auto"
+        >
+          ← Previous
+        </Button>
+
+        <div className="flex items-center gap-8">
+          <span className="text-sm text-gray-50">Epoch:</span>
+          <div className="w-24">
+            <TextInput
+              type="number"
+              value={inputValue}
+              onChange={handleInputChange}
+              onKeyPress={handleKeyPress}
+              size="sm"
+              error={inputError}
+              disabled={isLoading}
+            />
+          </div>
+          <Button
+            variant="outlined"
+            size="sm"
+            onClick={handleInputSubmit}
+            disabled={isLoading}
+            className="w-auto"
+          >
+            Go
+          </Button>
+        </div>
+
+        <Button
+          variant="outlined"
+          size="sm"
+          onClick={handleNext}
+          disabled={currentEpoch >= latestEpoch || isLoading}
+          className="w-auto"
+        >
+          Next →
+        </Button>
+      </div>
+
+      <div className="text-sm text-gray-50">
+        Showing epoch {currentEpoch} of {latestEpoch}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/home/components/index.ts
+++ b/src/pages/home/components/index.ts
@@ -1,2 +1,3 @@
+export { default as EpochPagination } from './EpochPagination'
 export { default as ProposalsList } from './ProposalsList'
 export { default as ProposalsTabs } from './ProposalsTabs'

--- a/src/store/apis/qli/qli.api.ts
+++ b/src/store/apis/qli/qli.api.ts
@@ -1,6 +1,12 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { qliBaseQuery } from './qli.base-query'
-import type { GetEndedProposalsResponse, GetUserResponse, Peer, Proposal } from './qli.types'
+import type {
+  GetEndedProposalsResponse,
+  GetEpochHistoryResponse,
+  GetUserResponse,
+  Peer,
+  Proposal
+} from './qli.types'
 
 export const qliApi = createApi({
   reducerPath: 'qliApi',
@@ -15,10 +21,18 @@ export const qliApi = createApi({
     getEndedProposals: build.query<GetEndedProposalsResponse, void>({
       query: () => '/Voting/History'
     }),
+    getEpochHistory: build.query<GetEpochHistoryResponse, number>({
+      query: (epoch: number) => `/Voting/EpochHistory/${epoch}`
+    }),
     getPeers: build.query<Peer[], void>({
       query: () => '/Public/Peers'
     })
   })
 })
 
-export const { useGetActiveProposalsQuery, useGetEndedProposalsQuery, useGetPeersQuery } = qliApi
+export const {
+  useGetActiveProposalsQuery,
+  useGetEndedProposalsQuery,
+  useGetEpochHistoryQuery,
+  useGetPeersQuery
+} = qliApi

--- a/src/store/apis/qli/qli.types.ts
+++ b/src/store/apis/qli/qli.types.ts
@@ -99,6 +99,11 @@ export interface GetEndedProposalsResponse {
   result: Proposal[]
 }
 
+export interface GetEpochHistoryResponse {
+  epoch: number
+  result: Proposal[]
+}
+
 export interface Peer {
   ipAddress: string
   currentTick: number


### PR DESCRIPTION
# Add Epoch-Based Pagination to Ended Proposals

## Summary
This PR adds epoch-based pagination to the ended proposals page using a new EpochHistory API endpoint. Key features include:

- **New API Integration**: Added `getEpochHistory` query that calls `/Voting/EpochHistory/{epoch}` 
- **EpochPagination Component**: Input field for epoch selection with Previous/Next navigation buttons
- **URL Query Integration**: Epoch parameter is reflected in URL (`?status=ended_proposals&epoch=123`) for shareable links
- **Smart Defaults**: Defaults to `latest epoch - 1` when no epoch is specified
- **Improved UX**: Removed "Epoch:" label, optimized input field sizing, and pre-fills with current epoch

The ended proposals tab now shows proposals from a specific epoch instead of all historical proposals, with intuitive navigation controls.